### PR TITLE
chore: enable Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,4 @@
 {
-  "enabled": false,
   "extends": ["config:base", "group:allNonMajor"],
   "rebaseStalePrs": true,
   "schedule": ["on Monday every 8 weeks of the year starting on the 4th week"]


### PR DESCRIPTION
## Description

While tracking the Renovate [logs](https://app.renovatebot.com/dashboard#github/zendeskgarden/chrome-extension), I discovered this repo was unintentionally disabled.
