### PR TITLE
fix: filter pane content from inspect highlighting

### DIFF
--- a/src/scripts/on.ts
+++ b/src/scripts/on.ts
@@ -22,7 +22,7 @@
     version: string,
     latestVersion: string
   ): void => {
-    const excludeIds = ['chrome.main', 'grid.grid', 'grid.col', 'grid.row'];
+    const excludeIds = ['chrome.main', 'grid.grid', 'grid.col', 'grid.row', 'pane', 'pane.content'];
 
     if (!excludeIds.includes(id)) {
       let color;


### PR DESCRIPTION
## Description

Adds `pane` and `pane.content` to the list of components that are filtered by Garden Inspect
